### PR TITLE
Add logger.Flush() blocking call to ensure all output is written

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -292,6 +292,17 @@ func (logger *Logger) log(logClass LogClass, message string) {
 	transitChannel <- b
 }
 
+// Flush is used to ensure the logger has flushed all queued log lines to its
+// outputs before returning.
+func (logger *Logger) Flush() {
+	b := &backgroundFlusher{
+		logger:     logger,
+		updateChan: make(chan struct{}),
+	}
+	transitChannel <- b
+	<-b.updateChan
+}
+
 // newLineData creates the struct that wraps a log message and will capture the
 // source of the logging message from the stack.
 func (logger *Logger) newLineData(logClass LogClass, message string) *LineData {

--- a/worker.go
+++ b/worker.go
@@ -13,7 +13,7 @@ var transitChannel chan backgroundWorker
 // This is used to schedule a background flush.
 type backgroundFlusher struct {
 	logger     *Logger
-	updateChan chan bool
+	updateChan chan struct{}
 }
 
 // Called in order to flush all output's associated with the logger.
@@ -25,7 +25,7 @@ func (b *backgroundFlusher) Process() {
 		o.Output.Flush()
 	}
 	if b.updateChan != nil {
-		b.updateChan <- true
+		close(b.updateChan)
 	}
 }
 


### PR DESCRIPTION
This adds a Flush() function onto the Logger class. This can be used to
ensure all queued log lines are flushed to their outputs before the
function returns.

This uses the backgroundFlusher worker, which has been there but unused.

FYI PR