### PR TITLE
Guard output slices against new writes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -46,8 +46,8 @@ var (
 
 // New returns a new Logger with the default configuration.
 func New() *Logger {
-	defaultOutputMutex.RLock()
-	defer defaultOutputMutex.RUnlock()
+	defaultOutputMutex.Lock()
+	defer defaultOutputMutex.Unlock()
 
 	logger := &Logger{
 		Fields:  make(map[string]interface{}),
@@ -115,10 +115,10 @@ func (logger *Logger) Clone() *Logger {
 	clone := &Logger{}
 
 	// copy the outputs
-	logger.outputMutex.RLock()
+	logger.outputMutex.Lock()
 	clone.outputs = make([]*loggerOutputWrapper, len(logger.outputs))
 	copy(clone.outputs, logger.outputs)
-	logger.outputMutex.RUnlock()
+	logger.outputMutex.Unlock()
 
 	// copy the fields
 	clone.Fields = make(map[string]interface{}, len(logger.Fields))


### PR DESCRIPTION
The `defaultOutputs` and `logger.outputs` slices were protected by mutexes that were being `RLock`-ed instead of `Lock`-ed. After the `RLock`, they `copy` the slices. Those slices could be mutated by another method during the `copy`.

There are also `RLock` calls in `worker.go`. I didn't change them because I don't understand that code well enough, but those should be scrutinized thoroughly.

@krobertson @shobhit85 @zquestz 