### PR TITLE
Add support for custom fields in the log messages for unit test logger

### DIFF
--- a/unittest/unittest_test.go
+++ b/unittest/unittest_test.go
@@ -1,17 +1,19 @@
 // Copyright 2012-2013 Apcera Inc. All rights reserved.
 
-package unittest_test
+package unittest
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+	"time"
 
 	"github.com/apcera/logray"
-	"github.com/apcera/logray/unittest"
 )
 
 func Example() {
 	// Setup
-	buffer := unittest.SetupBuffer()
+	buffer := SetupBuffer()
 	defer buffer.DumpToStdout()
 
 	// Unit tests go here.
@@ -22,7 +24,7 @@ func Example() {
 
 func ExamplePass() {
 	// Setup
-	buffer := unittest.SetupBuffer()
+	buffer := SetupBuffer()
 	defer buffer.DumpToStdout()
 
 	// Log a bunch of stuff.
@@ -36,4 +38,33 @@ func ExamplePass() {
 	buffer.Clear()
 
 	// Output: Expected output.
+}
+
+func TestLogBufferFields(t *testing.T) {
+
+	logBuffer := SetupBuffer()
+
+	logger := logray.New()
+	logger.SetField("TestField1", "Test1")
+	logger.SetField("TestField2", "Test2")
+	logger.Info("Test Log")
+
+	// Wait for a while and let the logger goroutine run.
+	time.Sleep(1 * time.Second)
+
+	if len(logBuffer.buffer) != 1 {
+		t.Fatalf("Expected: %d, Got: %d LineData items in the log buffer.", 1, len(logBuffer.buffer))
+	}
+
+	if len(logBuffer.fields) != 2 {
+		t.Fatalf("Expected: %d, Got: %d fields in the log buffer.", 2, len(logBuffer.fields))
+	}
+
+	if fv, ok := logBuffer.fields["TestField1"]; !ok || !strings.EqualFold(fv.(string), "Test1") {
+		t.Fatal("Unexpected field found in the log buffer")
+	}
+
+	if fv, ok := logBuffer.fields["TestField2"]; !ok || !strings.EqualFold(fv.(string), "Test2") {
+		t.Fatal("Unexpected field found in the log buffer")
+	}
 }


### PR DESCRIPTION
This change dumps logger fields out added to a logger for unit tests. Fields are supported for other default outputs like, `stdout` `stderr` etc. but unit tests use `logbuffer` output which did not support logger fields.

@zquestz @jpoler @wallyqs 