### PR TITLE
Fix UpdateOutput of logger by updating the correct outputs only.

### DIFF
--- a/logclass.go
+++ b/logclass.go
@@ -201,6 +201,6 @@ const (
 var (
 	// Defines the base log classes.
 	baseLogClasses = []LogClass{
-		TRACE, DEBUG, INFO, WARN, ERROR,
+		TRACE, DEBUG, INFO, WARN, ERROR, FATAL,
 	}
 )

--- a/logger_test.go
+++ b/logger_test.go
@@ -4,6 +4,8 @@ package logray
 
 import (
 	"net/url"
+	"os"
+	"path"
 	"testing"
 )
 
@@ -11,6 +13,9 @@ const (
 	formatString = "%color:class% %classfixed% " +
 		"%year%-%month%-%day% %hour%:%minute%:%second%.%nanosecond% " +
 		"%tzoffset% %tz% pid=%pid%"
+	fileFormatString = "%color:class% %classfixed% " +
+		"%year%-%month%-%day% %hour%:%minute%:%second%.%nanosecond% " +
+		"%tzoffset% %tz% pid=%pid% source='%sourcefile%:%sourceline%'"
 )
 
 func TestLoggerOutputsDownLevel(t *testing.T) {
@@ -28,7 +33,7 @@ func TestLoggerOutputsDownLevel(t *testing.T) {
 
 	logger := New()
 
-	// Update for DEBUG should not 	update the output.
+	// Update for DEBUG should not update the output.
 	logger.UpdateOutput(newDefaultUrlString, DEBUG)
 	if len(logger.outputs) > 2 {
 		t.Fatalf("More than 2 logger outputs defined: %d", len(logger.outputs))
@@ -237,5 +242,148 @@ func TestLoggerOutputsMultiLevel(t *testing.T) {
 	if restOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
 		restOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
 		t.Fatalf("Output: %v", restOutput.OutputWrapper)
+	}
+}
+
+func TestUpdateOutputSchemeMatch(t *testing.T) {
+
+	ResetDefaultOutput()
+
+	// Create new URI for default stdout output.
+	defaultUrlString := "stdout://?format=" + url.QueryEscape(formatString)
+	// Create new URI for file output.
+	logFile := path.Join(os.TempDir(), "logfile")
+	defaultFileUrlString := "file://" + logFile + "?format=" + url.QueryEscape(fileFormatString)
+	//Above generates a logfile in /tmp.
+	defer os.Remove(logFile)
+
+	// Append one extra field 'tid' to the url.
+	newDefaultUrlString := defaultUrlString + url.QueryEscape(" tid='%field:tid%'")
+
+	// Add default stdout output.
+	if err := AddDefaultOutput(defaultUrlString, DEBUGPLUS); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add default stdout output.
+	if err := AddDefaultOutput(defaultUrlString, TRACE); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add default file output.
+	if err := AddDefaultOutput(defaultFileUrlString, DEBUGPLUS); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := New()
+
+	// Update for TRACE should not update the output.
+	logger.UpdateOutput(newDefaultUrlString, TRACE)
+	if len(logger.outputs) > 3 {
+		t.Fatalf("More than 3 logger outputs defined: %d", len(logger.outputs))
+	}
+	debugPlusOutput := logger.outputs[0]
+	traceOutput := logger.outputs[1]
+	fileOutput := logger.outputs[2]
+
+	defaultUrl, err := url.Parse(defaultUrlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultFileUrl, err := url.Parse(defaultFileUrlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newUrl, err := url.Parse(newDefaultUrlString)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Must have old URI in debug plus stdout output.
+	if debugPlusOutput.OutputWrapper.URL.Scheme != defaultUrl.Scheme ||
+		debugPlusOutput.OutputWrapper.URL.RawQuery != defaultUrl.RawQuery {
+		t.Fatalf("Output: %v", debugPlusOutput.OutputWrapper)
+	}
+
+	// Must have old URI in debug plus file output.
+	if fileOutput.OutputWrapper.URL.Scheme != defaultFileUrl.Scheme ||
+		fileOutput.OutputWrapper.URL.RawQuery != defaultFileUrl.RawQuery {
+		t.Fatalf("Output: %v", debugPlusOutput.OutputWrapper)
+	}
+
+	// Must Have new URI in trace output.
+	if traceOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		traceOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", debugPlusOutput.OutputWrapper)
+	}
+
+	// Now update for DEBUG.
+	logger.UpdateOutput(newDefaultUrlString, DEBUG)
+
+	if len(logger.outputs) > 4 {
+		t.Fatalf("More than 4 logger outputs defined: %d", len(logger.outputs))
+	}
+
+	debugOutput := logger.outputs[0]
+	traceOutput = logger.outputs[1]
+	fileOutput = logger.outputs[2]
+	restOutput := logger.outputs[3]
+
+	// Must have new URL in the debug output.
+	if debugOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		debugOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", debugOutput.OutputWrapper)
+	}
+
+	if traceOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		traceOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", traceOutput.OutputWrapper)
+	}
+
+	if restOutput.OutputWrapper.URL.Scheme != defaultUrl.Scheme ||
+		restOutput.OutputWrapper.URL.RawQuery != defaultUrl.RawQuery {
+		t.Fatalf("Output: %v", restOutput.OutputWrapper)
+	}
+
+	// Must have old URI in debug plus file output.
+	if fileOutput.OutputWrapper.URL.Scheme != defaultFileUrl.Scheme ||
+		fileOutput.OutputWrapper.URL.RawQuery != defaultFileUrl.RawQuery {
+		t.Fatalf("Output: %v", debugPlusOutput.OutputWrapper)
+	}
+
+	// Now update for ALL.
+	logger.UpdateOutput(newDefaultUrlString, ALL)
+
+	if len(logger.outputs) > 4 {
+		t.Fatalf("More than 4 logger outputs defined: %d", len(logger.outputs))
+	}
+
+	debugOutput = logger.outputs[0]
+	traceOutput = logger.outputs[1]
+	fileOutput = logger.outputs[2]
+	restOutput = logger.outputs[3]
+
+	// Must have new URL in the debug output.
+	if debugOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		debugOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", debugOutput.OutputWrapper)
+	}
+
+	if traceOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		traceOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", traceOutput.OutputWrapper)
+	}
+
+	if restOutput.OutputWrapper.URL.Scheme != newUrl.Scheme ||
+		restOutput.OutputWrapper.URL.RawQuery != newUrl.RawQuery {
+		t.Fatalf("Output: %v", restOutput.OutputWrapper)
+	}
+
+	// Must have old URI in debug plus file output.
+	if fileOutput.OutputWrapper.URL.Scheme != defaultFileUrl.Scheme ||
+		fileOutput.OutputWrapper.URL.RawQuery != defaultFileUrl.RawQuery {
+		t.Fatalf("Output: %v", debugPlusOutput.OutputWrapper)
 	}
 }


### PR DESCRIPTION
This change fixes the updating of outputs of a logger. Each output
has a set of classes for which it is supposed to be applied on a line
data. In this change an intersection of classes is taken between an
output's classes and given classes to be updated. If intersection is
same as output's set of classes then whole output is updated otherwise
output is split into two, one for intersection and other for the rest.
Intersection one is updated with new URI but old one still keeps old URI.

For example if an output has been defined for DEBUGPLUS (= DEBUG | INFO | WARN | ERROR | FATAL | isPLUSDEF) class then applying an update for ALL will update this output and NO new output will be added.

But on the other hand if an update is applied for INFO then a new output wrapper will be generated with new URI for INFO class and old output wrapper will be saved for (DEBUGPLUS ^ INFO) & DEBUGPLUS = (DEBUG | WARN | ERROR | FATAL | isPLUSDEF).

Further if an update comes for ALL class then both of the output wrappers will be updated (INFO & (DEBUG | WARN | ERROR | FATAL | isPLUSDEF)) and no new output wrapper will be generated.

@wallyqs @olegshaldybin @jpoler @vitroth 