### PR TITLE
Use correct forward slashes when dealing with callers path

### DIFF
--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ package logray
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 )
@@ -17,8 +16,9 @@ func packageFilenameLine(ld *LineData, depth int) {
 		return
 	}
 
-	// strip the directory from the filename
-	fileParts := strings.Split(filename, string(os.PathSeparator))
+	// Strip the directory from the filename. Even on Windows this is slash
+	// delimited. See https://github.com/golang/go/issues/3335.
+	fileParts := strings.Split(filename, "/")
 	ld.SourceFile = fileParts[len(fileParts)-1]
 	ld.SourceLine = linenum
 


### PR DESCRIPTION
The filename returned from runtime.Caller is forward slash
delimited which has had an open issue for years:
https://github.com/golang/go/issues/3335

This changes makes it such that the file:line is reported
properly instead of the full-path:line which is the current
behavior on Windows. When dealing with small log lines,
that long path can represent a sizable percentage of the
total size of the log file.